### PR TITLE
update for orr sales informaton

### DIFF
--- a/src/custom-addons/orr_sales/__init__.py
+++ b/src/custom-addons/orr_sales/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/src/custom-addons/orr_sales/__init__.py
+++ b/src/custom-addons/orr_sales/__init__.py
@@ -1,1 +1,1 @@
-from . import res_partner
+from . import model

--- a/src/custom-addons/orr_sales/__manifest__.py
+++ b/src/custom-addons/orr_sales/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name':'ORR Sale',
+    'author': 'ORR Dev trg',
+    'depends':[
+        'sale',
+        'contacts'
+    ],
+    'application':False,
+    'installable':True,
+    'data': [
+        'views/res_partner.xml',
+        'views/product.xml',
+    ]   
+} 

--- a/src/custom-addons/orr_sales/model/__init__.py
+++ b/src/custom-addons/orr_sales/model/__init__.py
@@ -1,0 +1,1 @@
+from .import res_partner

--- a/src/custom-addons/orr_sales/model/res_partner.py
+++ b/src/custom-addons/orr_sales/model/res_partner.py
@@ -1,0 +1,22 @@
+from odoo import models, fields, api
+
+class Partners(models.Model):
+    _inherit = "res.partner"
+ 
+    @api.depends('name')
+    def name_get(self):
+        #super().name_get()
+        res = []
+        print('here')
+        for record in self:
+            print(record.id)
+            name = record.name
+            city = record.city
+            print('city: %s' % (city))
+            state = record.state_id.name
+            print(state )#% (city.state))
+            display_name = '%s ( %s %s )' % (name,city,state)
+            #print('display_name: %s %s %s' %s (name,city,state))
+            res.append((record.id,display_name))
+        print(res)
+        return res

--- a/src/custom-addons/orr_sales/model/res_partner.py
+++ b/src/custom-addons/orr_sales/model/res_partner.py
@@ -9,14 +9,10 @@ class Partners(models.Model):
         res = []
         print('here')
         for record in self:
-            print(record.id)
             name = record.name
             city = record.city
-            print('city: %s' % (city))
             state = record.state_id.name
-            print(state )#% (city.state))
             display_name = '%s ( %s %s )' % (name,city,state)
-            #print('display_name: %s %s %s' %s (name,city,state))
             res.append((record.id,display_name))
         print(res)
         return res

--- a/src/custom-addons/orr_sales/module/__init__.py
+++ b/src/custom-addons/orr_sales/module/__init__.py
@@ -1,0 +1,1 @@
+from .import res_partner

--- a/src/custom-addons/orr_sales/module/res_partner.py
+++ b/src/custom-addons/orr_sales/module/res_partner.py
@@ -1,0 +1,22 @@
+from odoo import models, fields, api
+
+class Partners(models.Model):
+    _inherit = "res.partner"
+ 
+    @api.depends('name')
+    def name_get(self):
+        #super().name_get()
+        res = []
+        print('here')
+        for record in self:
+            print(record.id)
+            name = record.name
+            city = record.city
+            print('city: %s' % (city))
+            state = record.state_id.name
+            print(state )#% (city.state))
+            display_name = '%s ( %s %s )' % (name,city,state)
+            #print('display_name: %s %s %s' %s (name,city,state))
+            res.append((record.id,display_name))
+        print(res)
+        return res

--- a/src/custom-addons/orr_sales/views/product.xml
+++ b/src/custom-addons/orr_sales/views/product.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <record id="sale.product_template_action"
+                model="ir.actions.act_window">
+                <field name="view_mode">tree,kanban,form,activity</field>
+                <field name="view_ids" eval="[(6,0,[])]"></field>
+                <field name="view_id" />
+    </record>
+</odoo> 

--- a/src/custom-addons/orr_sales/views/res_partner.xml
+++ b/src/custom-addons/orr_sales/views/res_partner.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="base.action_partner_customer_form"
+                model="ir.actions.act_window">
+                <field name="view_mode">tree,kanban,form,activity</field>
+                <field name="view_ids" eval="[(6,0,[])]"></field>
+    </record>
+    <record id="contacts.action_contacts"
+                model="ir.actions.act_window">
+                <field name="view_mode">tree,kanban,form,activity</field>
+                <field name="view_ids" eval="[(6,0,[])]"></field>
+    </record>
+</odoo> 


### PR DESCRIPTION
#71 [Doing] Orr: Change default view of Products to List View
The default used view type, or view reference, are set on the Window Action (ir.actions.act_window).
Locate the XML ID of the Window Actions to modify, and change them using a module XML data file. Set the view_mode field value to one starting with tree. We might need to set the view_ref to an empty value.

For Sales / Products / Products:
id="sale.product_template_action"
view_mode="tree,kanban,form,activity"
view_id=""
For Inventory and Field Service:
Action id="stock.product_template_action_product"
view_mode="tree,kanban,form"
