### PR TITLE
#114 update to move equipment postion after project

### DIFF
--- a/src/custom-addons/osi_orr_recurring_workflow/views/fsm_recurring.xml
+++ b/src/custom-addons/osi_orr_recurring_workflow/views/fsm_recurring.xml
@@ -5,12 +5,12 @@
         <field name="inherit_id" ref="fieldservice_recurring.fsm_recurring_form_view"/>
         <field name="arch" type="xml">
             <field name="company_id" position="after">
-                <field name="fsm_equipment_id"/>
                 <field name="agreement_id"/>
                 <field name="serviceprofile_id"/>
             </field>
             <field name="max_orders" position="after">
                 <field name="project_id"/>
+                <field name="fsm_equipment_id"/>
                 <field name="task_id"/>
             </field>
         </field>


### PR DESCRIPTION
trg
#114 [NEW] Orr: Change order of Equipment, Product on Sales Order and Quotations - select Product on sales order, then select equipment.
The equipment_id field is being added to the SO Lines at:
osi_orr_recurring_workflow.view_order_form_orr_recurring
Modify this custom extension module so that the field is added after "product_id", rather than before.
